### PR TITLE
[ Step11 & Step 12 ] 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,12 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 
+	// redis
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+	// Redisson
+	implementation("org.redisson:redisson-spring-boot-starter:3.18.0")
+
 	// OpenAPI / Swagger
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 version: '3'
 services:
+  redis:
+    image: redis:7.4.4-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
   mysql:
     image: mysql:8.0
     ports:

--- a/src/main/java/kr/hhplus/be/server/application/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/CouponService.java
@@ -41,10 +41,9 @@ public class CouponService {
     )
     @Transactional
     public Coupon issueCoupon(int userId, int policyId) {
-        // 쿠폰 정책 조회 (비관적 락 적용)
-        CouponPolicy policy = couponPolicyRepository.findByIdWithLock(policyId)
-            .orElseThrow(() -> new IllegalArgumentException("쿠폰 정책을 찾을 수 없습니다."));
-
+        // 쿠폰 정책 조회 (캐시)
+        CouponPolicy policy = getCouponPolicyById(policyId);
+        
         // 재고 확인
         if (policy.getIssuedCount() >= policy.getMaxCount()) {
             throw new IllegalStateException("쿠폰이 소진되었습니다.");

--- a/src/main/java/kr/hhplus/be/server/application/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/CouponService.java
@@ -1,13 +1,17 @@
 package kr.hhplus.be.server.application.coupon;
 
+import kr.hhplus.be.server.common.lock.DistributedLock;
 import kr.hhplus.be.server.domain.coupon.Coupon;
 import kr.hhplus.be.server.domain.coupon.CouponPolicy;
 import kr.hhplus.be.server.domain.coupon.CouponPolicyRepository;
 import kr.hhplus.be.server.domain.coupon.CouponRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CacheEvict;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional(readOnly = true)
@@ -22,6 +26,19 @@ public class CouponService {
         this.couponPolicyRepository = couponPolicyRepository;
     }
 
+    // 쿠폰 정책 조회
+    @Cacheable(value = "coupon_policy", key = "#policyId")
+    public CouponPolicy getCouponPolicyById(int policyId) {
+        return couponPolicyRepository.findById(policyId)
+            .orElseThrow(() -> new IllegalArgumentException("쿠폰 정책을 찾을 수 없습니다."));
+    }
+
+    @DistributedLock(
+        key = "'coupon_policy:' + #policyId",
+        waitTime = 10,
+        leaseTime = 30,
+        timeUnit = TimeUnit.SECONDS
+    )
     @Transactional
     public Coupon issueCoupon(int userId, int policyId) {
         // 쿠폰 정책 조회 (비관적 락 적용)

--- a/src/main/java/kr/hhplus/be/server/application/product/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/ProductService.java
@@ -4,6 +4,8 @@ import kr.hhplus.be.server.domain.product.Product;
 import kr.hhplus.be.server.domain.product.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CacheEvict;
 
 import java.util.List;
 
@@ -23,7 +25,8 @@ public class ProductService {
         return productRepository.findAll();
     }
     
-    // 상품 조회
+    // 상품 조회 
+    @Cacheable(value = "product", key = "#productId")
     public Product getProductById(int productId) {
 
         return productRepository.findById(productId)

--- a/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.common.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    // 락의 이름
+    String key();
+
+    // 락의 시간 단위
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    // 락을 기다리는 시간 - 락 획득을 위해 waitTime만큼 대기한다
+    long waitTime() default 5L;
+
+    // 락 임대 시간 - 락 획득한 이후 leaseTime이 지나면 락을 해제한다
+    long leaseTime() default 3L;
+}

--- a/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAop.java
@@ -1,0 +1,81 @@
+package kr.hhplus.be.server.common.lock;
+
+import kr.hhplus.be.server.common.support.CustomSpringELParser;
+import kr.hhplus.be.server.config.AopForTransaction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+/**
+ * @DistributedLock 선언 시 수행되는 Aop class
+ */
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAop {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    @Around("@annotation(kr.hhplus.be.server.common.lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        log.info("=== 분산락 시작 ===");
+        log.info("메서드: {}, 락 키: {}", method.getName(), key);
+        log.info("대기시간: {}, 임대시간: {}, 시간단위: {}", distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+        
+        RLock rLock = redissonClient.getLock(key);
+        log.info("Redisson 락 객체 생성 완료");
+
+        try {
+            log.info("락 획득 시도 중...");
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            log.info("락 획득 결과: {}", available);
+            
+            if (!available) {
+                log.warn("락 획득 실패! 메서드: {}, 키: {}", method.getName(), key);
+                throw new IllegalStateException("분산락 획득에 실패했습니다. 잠시 후 다시 시도해주세요.");
+            }
+
+            log.info("락 획득 성공! 메서드 실행 시작");
+            // AopForTransaction을 통해 트랜잭션 전파
+            Object result = aopForTransaction.proceed(joinPoint);
+            log.info("메서드 실행 완료, 결과: {}", result);
+            return result;
+        } catch (InterruptedException e) {
+            log.error("락 획득 중 인터럽트 발생: {}", e.getMessage());
+            Thread.currentThread().interrupt();
+            throw new InterruptedException("분산락 대기 중 인터럽트가 발생했습니다.");
+        } catch (Exception e) {
+            log.error("메서드 실행 중 예외 발생: {}", e.getMessage(), e);
+            throw e;
+        } finally {
+            try {
+                if (rLock.isHeldByCurrentThread()) {
+                    rLock.unlock();
+                    log.info("락 해제 완료");
+                } else {
+                    log.info("현재 스레드가 락을 보유하지 않음");
+                }
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson Lock Already UnLock serviceName={} key={}",
+                        method.getName(), key);
+            }
+            log.info("=== 분산락 종료 ===");
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/support/CustomSpringELParser.java
+++ b/src/main/java/kr/hhplus/be/server/common/support/CustomSpringELParser.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.common.support;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/AopForTransaction.java
+++ b/src/main/java/kr/hhplus/be/server/config/AopForTransaction.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.config;
+
+import org.springframework.transaction.annotation.Transactional;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/CacheConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/CacheConfig.java
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(30)) // 기본 TTL 30분
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(config)
+            .withCacheConfiguration("product", 
+                RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(10))) // 상품 캐시 10분
+            .withCacheConfiguration("coupon_policy", 
+                RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5))) // 쿠폰 정책 캐시 5분
+            .build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/RedissonConfig.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort)
+            .setConnectionPoolSize(64)
+            .setConnectionMinimumIdleSize(24)
+            .setConnectTimeout(10000)
+            .setTimeout(3000)
+            .setRetryAttempts(3)
+            .setRetryInterval(1500);
+        
+        return Redisson.create(config);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,12 @@ springdoc:
     config-url: /api-docs/swagger-config
     url: /api-docs
 
+logging:
+  level:
+    kr.hhplus.be.server.common.lock: INFO
+    org.redisson: INFO
+    kr.hhplus.be.server.application.coupon: INFO
+
 ---
 spring.config.activate.on-profile: local, test
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,12 +11,25 @@ spring:
       connection-timeout: 10000
       max-lifetime: 60000
     driver-class-name: com.mysql.cj.jdbc.Driver
+  data:
+    redis:
+      port: 6379
+      host: localhost
+      timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+          max-wait: -1ms
+  cache:
+    type: redis
   jpa:
     open-in-view: false
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
@@ -39,3 +52,15 @@ spring:
     url: jdbc:mysql://localhost:3307/hhplus?characterEncoding=UTF-8&serverTimezone=UTC
     username: application
     password: application
+  data:
+    redis:
+      host: ${spring.data.redis.host:localhost}
+      port: ${spring.data.redis.port:6379}
+      timeout: 2000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+          max-wait: -1ms
+

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -5,27 +5,42 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
 class TestcontainersConfiguration {
 
 	public static final MySQLContainer<?> MYSQL_CONTAINER;
+	public static final GenericContainer<?> REDIS_CONTAINER;
 
 	static {
+		// MySQL 컨테이너 설정
 		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
 			.withDatabaseName("hhplus")
 			.withUsername("test")
 			.withPassword("test")
-			.withReuse(true);  // 컨테이너 재사용 활성화
+			.withReuse(true);
+		
+		// Redis 컨테이너 설정
+		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+			.withExposedPorts(6379)
+			.withReuse(true);
 		
 		try {
+			// MySQL 시작
 			MYSQL_CONTAINER.start();
 			System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
 			System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
 			System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+			
+			// Redis 시작
+			REDIS_CONTAINER.start();
+			System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+			System.setProperty("spring.data.redis.port", String.valueOf(REDIS_CONTAINER.getMappedPort(6379)));
+			
 		} catch (Exception e) {
-			System.err.println("Failed to start MySQL container: " + e.getMessage());
+			System.err.println("Failed to start containers: " + e.getMessage());
 			throw e;
 		}
 	}
@@ -34,6 +49,9 @@ class TestcontainersConfiguration {
 	public void preDestroy() {
 		if (MYSQL_CONTAINER != null && MYSQL_CONTAINER.isRunning()) {
 			MYSQL_CONTAINER.stop();
+		}
+		if (REDIS_CONTAINER != null && REDIS_CONTAINER.isRunning()) {
+			REDIS_CONTAINER.stop();
 		}
 	}
 }


### PR DESCRIPTION
## :pushpin: PR 제목 규칙
[ STEP 11 & STEP 12 ] 최민지 - e-commerce

---
### **핵심 체크리스트** :white_check_mark:

#### :one: 분산락 적용 (3개)
- [ o ] 적절한 곳에 분산락이 사용되었는가? 
- [ ? ] 트랜젝션 순서와 락순서가 보장되었는가?

#### :two: 통합 테스트 (2개)
- [ o ] infrastructure 레이어를 포함하는 통합 테스트가 작성되었는가?
- [ ? ] 핵심 기능에 대한 흐름이 테스트에서 검증되었는가?
- [ o  ] 동시성을 검증할 수 있는 테스트코드로 작성 되었는가?
- [ o ] Test Container 가 적용 되었는가?

#### :three: Cache 적용 (3개)
- [ o  ] 적절하게 Key 적용이 되었는가?

---
#### STEP11
- [ o ] Redis 분산락 적용
- [ o ] Test Container 구성
- [ o ] 기능별 통합 테스트

#### STEP12
- [ o ] 캐시 필요한 부분 분석
- [ o  ] redis 기반의 캐시 적용
- [ o ] 성능 개선 등을 포함한 보고서 제출
---

# 📝 캐시 전략 분석 보고서

## �� 캐시가 필요한 부분 분석

### (1) 상품 상세 조회
- **적용 대상**: 인기 있는 상품들
- **적용 이유**:
  - 인기 상품은 조회 빈도가 높음
  - 데이터베이스 부하 감소
  - 응답 시간 개선
- **구현 방식**: Redis 캐시 + 선택적 캐싱
- **현재 상태**: `@Cacheable(value = "product", key = "#productId")` 적용됨

### (2) 쿠폰 정책 조회
- **적용 대상**: 쿠폰 정책 정보 (by policyId)
- **적용 이유**:
  - 이벤트 발생 시 조회 빈도 급증
  - 정책 정보는 자주 변경되지 않음
  - 쿠폰 발급 시 빠른 정책 정보 접근 필요
- **현재 상태**: `@Cacheable(value = "coupon_policy", key = "#policyId")` 적용됨

## 🔄 변경 사항

### 기존 시스템에서 분산락으로 전환
- **기존 방식**: 비관적 락 (`@Lock(LockModeType.PESSIMISTIC_WRITE)`)
  - `ProductService.reduceStockWithLock()` - 개별 상품 재고 차감
  - `CouponPolicyJpaRepository.findByIdWithLock()` - 쿠폰 정책 조회 시 락
- **개선된 방식**: Redis 기반 분산락
  - `OrderFacade.createOrderWithPayment()` - 주문 시 전체 재고 차감
  - `CouponService.issueCoupon()` - 쿠폰 발급 시 정책별 락

### 전환 이유
- **트래픽 증가**: 동시 요청 처리량 향상 필요
- **성능 개선**: 데이터베이스 락 대기 시간 단축
- **확장성**: Redis 기반으로 수평 확장 가능

## 📊 현재 성능 현황

### 캐시 적용 현황
- **상품 조회**: `@Cacheable` 적용됨
- **쿠폰 정책**: `@Cacheable` 적용됨
- **단, 캐시 동기화 문제로 인해 쿠폰 발급 시 데이터 일관성 이슈 발생**

### 분산락 적용 현황
- **재고 차감**: OrderFacade에서 분산락 적용
- **개별 재고 차감**: ProductService에서 여전히 비관적 락 사용
- **쿠폰 발급**: CouponService에서 분산락 적용

## �� 향후 성능 개선 계획

**캐싱이 가장 필요한 부분은 '인기 상품 조회 기능'인거 같습니다. 아직 이 부분의 기능 구현이 되지 않아서 향후 개선 후 캐싱도 추가하려 합니다.**

---
❓ 질문 
1. 분산락 - 재고 차감 
-락을 획득하고 트랜잭션을 시작하는 흐름이 성공적으로 실행되고 있는지 궁굼합니다. 
-재고 차감 분산락 키가 현재 'product:' + #sortedProductIds로 설정했는데, 이 방식이 최적인지 궁굼합니다. 상품별로 개별 락을 거는 것이 더 효율적일까요? 

2. 캐싱 - 쿠폰 발급
-동시성 테스트를 돌려보았는데 캐시된 쿠폰 정보가 업데이트 되지 않는 것 같습니다... 이를 해결하려면 '쿠폰 발급 후 캐시를 바로 삭제해야 할까요?' 다른 좋은 방법이 있는지 궁굼합니다! ㅎㅎ



---
📌 **간단 회고** (3줄 이내)
- **잘한 점**: 분산락과 캐싱을 접해보았습니다. lock과 캐싱이 흥미로웠습니다.
- **어려운 점**: 분산락과 트랜잭션의 흐름이 성공적으로 수행되지 않은 것 같습니다. 
- **다음 시도**: 향후에 인기 상품 조회 기능을 추가하고 캐싱을 적용해야 겠습니다.